### PR TITLE
Do not mutate panics

### DIFF
--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -362,7 +362,6 @@ func processFile(opts *options, tmpDir, file string, mutators []mutatorItem, mut
 func mutate(opts *options, mutators []mutatorItem, mutationBlackList map[string]struct{}, mutationID int, pkg *types.Package, info *types.Info, file string, fset *token.FileSet, src ast.Node, node ast.Node, tmpFile string, execs []string, stats *mutationStats) int {
 	for _, m := range mutators {
 		debug(opts, "Mutator %s", m.Name)
-
 		changed := mutesting.MutateWalk(pkg, info, node, m.Mutator)
 
 		for {

--- a/mutator/branch/mutatecase.go
+++ b/mutator/branch/mutatecase.go
@@ -20,6 +20,9 @@ func MutatorCase(pkg *types.Package, info *types.Info, node ast.Node) []mutator.
 	}
 
 	old := n.Body
+	if !mutator.CheckForPanic(old) {
+		return nil
+	}
 
 	return []mutator.Mutation{
 		{

--- a/mutator/branch/mutateelse.go
+++ b/mutator/branch/mutateelse.go
@@ -26,6 +26,10 @@ func MutatorElse(pkg *types.Package, info *types.Info, node ast.Node) []mutator.
 
 	old := n.Else
 
+	if !mutator.CheckForPanic([]ast.Stmt{old}) {
+		return nil
+	}
+
 	return []mutator.Mutation{
 		{
 			Change: func() {

--- a/mutator/branch/mutateif.go
+++ b/mutator/branch/mutateif.go
@@ -21,6 +21,10 @@ func MutatorIf(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mu
 
 	old := n.Body.List
 
+	if !mutator.CheckForPanic(old) {
+		return nil
+	}
+
 	return []mutator.Mutation{
 		{
 			Change: func() {

--- a/mutator/mutator.go
+++ b/mutator/mutator.go
@@ -48,3 +48,20 @@ func Register(name string, mutator Mutator) {
 
 	mutatorLookup[name] = mutator
 }
+
+func CheckForPanic(stmts []ast.Stmt) bool {
+	//Don't mutate if there's a panic statement
+	for _, node := range stmts {
+		switch n := node.(type) {
+		case *ast.ExprStmt:
+			call, ok := n.X.(*ast.CallExpr)
+			if ok {
+				ident, ok := call.Fun.(*ast.Ident)
+				if ok && ident.Name == "panic" {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}

--- a/mutator/statement/remove.go
+++ b/mutator/statement/remove.go
@@ -35,9 +35,18 @@ func MutatorRemoveStatement(pkg *types.Package, info *types.Info, node ast.Node)
 		l = n.List
 	case *ast.CaseClause:
 		l = n.Body
+	case *ast.CallExpr:
+		ident, ok := n.Fun.(*ast.Ident)
+		if ok && ident.Name == "panic" {
+			return nil
+		}
 	}
 
 	var mutations []mutator.Mutation
+
+	if !mutator.CheckForPanic(l) {
+		return nil
+	}
 
 	for i, ni := range l {
 		if checkRemoveStatement(ni) {


### PR DESCRIPTION
Prevents mutations of panics. Unit testing panics is the wrong approach, so we shouldn't be encouraging test coverage of panics by producing mutations of them.

May add things like `log.Fatal` to the mix as well. 